### PR TITLE
Einleitender Text für Fehlermeldungen als objparam angeben können

### DIFF
--- a/lib/yform.php
+++ b/lib/yform.php
@@ -85,6 +85,7 @@ class rex_yform
         $this->objparams['form_hiddenfields'] = [];
 
         $this->objparams['warning'] = [];
+        $this->objparams['warning_intro'] = '';
         $this->objparams['warning_messages'] = [];
 
         $this->objparams['hide_top_warning_messages'] = false;

--- a/ytemplates/bootstrap/errors.tpl.php
+++ b/ytemplates/bootstrap/errors.tpl.php
@@ -9,7 +9,10 @@
 
 <?php
 if ($this->objparams['warning_messages'] || $this->objparams['unique_error']):
-    if ($this->objparams['Error-occured']): ?>
+    if ($this->objparams['Error-occured']): 
+        if($this->objparams['warning_intro']) { ?>
+            <p><?= $this->objparams['warning_intro'] ?></p>
+        <?php } ?>
         <dl class="dl-horizontal">
             <dt><?= $this->objparams['Error-occured'] ?></dt>
             <dd>


### PR DESCRIPTION
closes #240 Einleitender Text, z.B. `Ihre Angaben wurden noch nicht verarbeitet, bitte korrigieren Sie folgende Angaben:` und danach erst werden die Fehler aufgelistet.