### PR TITLE
Enable whitespace linkebreak for multiple validation params

### DIFF
--- a/plugins/manager/lib/list_tools.php
+++ b/plugins/manager/lib/list_tools.php
@@ -15,6 +15,7 @@ class rex_yform_list_tools
         switch ($p['list']->getValue('type_id')) {
             case 'validate':
                 $styleClass = 'yform-manager-type-validate';
+                $p['value'] = str_replace(',', ', ', $p['value']);
                 break;
             case 'action':
                 $styleClass = 'yform-manager-type-action';


### PR DESCRIPTION
closes #1338

![image](https://github.com/yakamara/yform/assets/3855487/8709eeab-465f-48f3-a3f2-ba296718c881)
