### PR TITLE
`JSON_PRETTY_PRINT` Table Manager Export

### DIFF
--- a/plugins/manager/lib/yform/manager/table/api.php
+++ b/plugins/manager/lib/yform/manager/table/api.php
@@ -130,7 +130,7 @@ class rex_yform_manager_table_api
             ];
         }
 
-        return json_encode($export);
+        return json_encode($export, JSON_PRETTY_PRINT);
     }
 
     /**


### PR DESCRIPTION
Siehe https://www.php.net/manual/en/function.json-encode.php

Ermöglicht einfacher, ein Diff anzuzeigen, wenn man Tablesets in eigenen Addons benutzt oder bei Git vergleicht.