### PR TITLE
Umbenennen Tokens -> Token

### DIFF
--- a/docs/05_rest.md
+++ b/docs/05_rest.md
@@ -10,7 +10,7 @@ Die Klasse muss zunächst registriert werden siehe [YOrm](yorm.md), damit auf di
 
 > Hinweis: Die Tabellem müssen mit YForm verwaltbar sein, da diese Felder automatisch genutzt werden.
 
-Die Schnittstelle orientiert sich an https://jsonapi.org/format/. Aufrufe und JSON Formate sind ähnlich bis exakt so aufgebaut.
+Die Schnittstelle orientiert sich an <https://jsonapi.org/format/>. Aufrufe und JSON Formate sind ähnlich bis exakt so aufgebaut.
 
 [Im Rahmen einer REDAXOHour ist eine Video Einführung entstanden, die viele Punkte dieses Kapitels erklärt.](https://www.youtube.com/watch?v=o88DHxsOLOs)
 
@@ -18,12 +18,11 @@ Die Schnittstelle orientiert sich an https://jsonapi.org/format/. Aufrufe und JS
 
 Die Zugriff über REST muss für jeden Endpoint einzeln definiert werden. D.h. man muss für jede Tabelle und für unterschiedliche Nutzungszenarien diese fest definieren.
 
-Die Standardroute der REST-API ist auf "/rest" gesetzt, d.h. hierunter können eigene Routen definiert werden. 
+Die Standardroute der REST-API ist auf "/rest" gesetzt, d.h. hierunter können eigene Routen definiert werden.
 
 Die Konfiguration wird über PHP festgelegt und sollte im project-AddOn in der boot.php abgelegt werden. Kann aber auch an andere Stelle abgelegt werden, solange diese während der Initialisierung aufgerufen wird.
 
 Hier ein Beispiel, um YCom-User über die REST-API zu verwalten:
-
 
 ```php
 <?php
@@ -77,10 +76,8 @@ $route = new \rex_yform_rest_route(
 \rex_yform_rest::addRoute($route);
 ```
 
-Dieses Beispiel führt dazu, dass man User über das PlugIn auslesen kann, wie auch User einspielen kann, aber nur mit den Feldern: login,email,ycom_groups. 
+Dieses Beispiel führt dazu, dass man User über das PlugIn auslesen kann, wie auch User einspielen kann, aber nur mit den Feldern: login,email,ycom_groups.
 Löschen kann man jeden User. Über Filter bei id oder login, lassen sich bestimmte User filtern und als Ganzes löschen.
-
-
 
 ### Route-Konfiguration
 
@@ -98,7 +95,6 @@ Beispiele
 
 Wenn man keine Authentifizierung einträgt kann jeder diese Daten entsprechend der weiteren Konfiguration nutzen. Sollte man nur bei Tabellen wie PLZ oder ähnlich offensichtlich freien Daten machen.
 
-
 `table`
 Hier wird die entsprechend Tabelle übergeben, die in YOrm definiert ist.
 
@@ -108,8 +104,8 @@ Beispiel
 
 ## Nutzung eines Endpoints
 
-URL (z. B. https://domain/rest/v1/user)
-In den Beispielen wird davon ausgegangen, dass es keine eigene Authentifizierung gibt. Um zu sehen wie die Aufrufe funktionieren bitte hier https://jsonapi.org/format/ nachschlagen. 
+URL (z. B. <https://domain/rest/v1/user>)
+In den Beispielen wird davon ausgegangen, dass es keine eigene Authentifizierung gibt. Um zu sehen wie die Aufrufe funktionieren bitte hier <https://jsonapi.org/format/> nachschlagen.
 
 ### GET
 
@@ -120,12 +116,14 @@ RequestType: ````GET````
 URL: ```https://url.localhost/rest/v1/users/[id]```
 
 Header:
+
 ```
 Content-Type: application/x-www-form-urlencoded
 token: [token]
 ```
 
 Response:
+
 ```
 {
     "id": "[id]",
@@ -147,7 +145,6 @@ Response:
     }
 }
 ```
-
 
 #### Filter
 
@@ -171,13 +168,15 @@ RequestType: ````POST````
 
 URL: ```https://url.localhost/rest/v1/users/```
 
-Header: 
+Header:
+
 ```
 Content-Type: application/x-www-form-urlencoded
 token: [token]
 ```
 
-Body: 
+Body:
+
 ```
 {
     "data": {
@@ -211,12 +210,14 @@ RequestType: ````DELETE````
 URL: ```https://url.localhost/rest/v1/users/?filter[login]=jannie```
 
 Header:
+
 ```
 Content-Type: application/x-www-form-urlencoded
 token: [token]
 ```
 
 Response:
+
 ```
 {
     "all": 1,
@@ -238,12 +239,14 @@ URL: ```https://url.localhost/rest/v1/users/[id]```
 oder ```https://url.localhost/rest/v1/users/?filter[id]=[id]```
 
 Header:
+
 ```
 Content-Type: application/x-www-form-urlencoded
 token: [token]
 ```
 
 Response:
+
 ```
 {
     "all": 1,
@@ -256,6 +259,7 @@ Response:
 ```
 
 Response ohne Treffer:
+
 ```
 {
     "all": 0,
@@ -263,15 +267,16 @@ Response ohne Treffer:
     "failed": 0
 }
 ```
+
 ## Authentifizierung
 
 ### Standardauthentifizierung
 
-Wenn im Model folgende Authentifizerung angegeben wurde: `'\rex_yform_rest_auth_token::checkToken()'` ist das die Standardauthentifizierung mit Tokens aus der YForm:Rest:Tokenverwaltung.
+Wenn im Model folgende Authentifizerung angegeben wurde: `'\rex_yform_rest_auth_token::checkToken()'` ist das die Standardauthentifizierung mit Token aus der YForm:Rest:Tokenverwaltung.
 
-Die hier erstellen Token werden entsprechend überprüft und müssen im Header übergeben werden. `token=###meintoken###` Nur aktive Tokens funktionieren. 
-Über das REST PlugIn kann man im Backend diese Zugriffe einschränken und tracken. D.h. Es können Einschränkungen wir Zugriffe / Stunde oder ähnliches eingestellt werden. 
-Jeder Zugriff auf die REST-API wird erfasst. 
+Die hier erstellen Token werden entsprechend überprüft und müssen im Header übergeben werden. `token=###meintoken###` Nur aktive Token funktionieren.
+Über das REST PlugIn kann man im Backend diese Zugriffe einschränken und tracken. D.h. Es können Einschränkungen wir Zugriffe / Stunde oder ähnliches eingestellt werden.
+Jeder Zugriff auf die REST-API wird erfasst.
 
 ## Header
 

--- a/plugins/rest/lang/de_de.lang
+++ b/plugins/rest/lang/de_de.lang
@@ -1,8 +1,8 @@
 yform_rest = REST-API
 
-yform_rest_token = Tokens
+yform_rest_token = Token
 
-yform_rest_token_header = REST: Tokens
+yform_rest_token_header = REST: Token
 
 yform_rest_token_name = Name
 yform_rest_token_token = Token
@@ -22,8 +22,8 @@ yform_rest_token_added = Token wurde hinzugefügt
 yform_rest_token_header_summary
 
 yform_rest_token_header_description
-yform_rest_token_not_found = Keine Tokens gefunden
-yform_rest_token_caption = Liste der Tokens
+yform_rest_token_not_found = Keine Token gefunden
+yform_rest_token_caption = Liste der Token
 
 yform_rest_token_name_validate = Bitte eine Bezeichnung/Name eingeben
 yform_rest_token_token_validate = Bitte einen Token eintragen

--- a/plugins/rest/lang/en_gb.lang
+++ b/plugins/rest/lang/en_gb.lang
@@ -1,8 +1,8 @@
 yform_rest = REST-API
 
-yform_rest_token = Tokens
+yform_rest_token = Token
 
-yform_rest_token_header = REST: Tokens
+yform_rest_token_header = REST: Token
 
 yform_rest_token_name = Name
 yform_rest_token_token = Token
@@ -22,8 +22,8 @@ yform_rest_token_added = Token added
 yform_rest_token_header_summary
 
 yform_rest_token_header_description
-yform_rest_token_not_found = No tokens found
-yform_rest_token_caption = List of tokens
+yform_rest_token_not_found = No token found
+yform_rest_token_caption = List of token
 
 yform_rest_token_name_validate = Please enter a description/name
 yform_rest_token_token_validate = Please create a token

--- a/plugins/rest/lang/es_es.lang
+++ b/plugins/rest/lang/es_es.lang
@@ -1,8 +1,8 @@
 yform_rest = REST-API
 
-yform_rest_token = Tokens
+yform_rest_token = Token
 
-yform_rest_token_header = REST: Tokens
+yform_rest_token_header = REST: Token
 
 yform_rest_token_name = Nombre
 yform_rest_token_token = Token

--- a/plugins/rest/lang/sv_se.lang
+++ b/plugins/rest/lang/sv_se.lang
@@ -1,8 +1,8 @@
 yform_rest = REST-API
 
-yform_rest_token = Tokens
+yform_rest_token = Token
 
-yform_rest_token_header = REST: Tokens
+yform_rest_token_header = REST: Token
 
 yform_rest_token_name = Namn
 yform_rest_token_token = Token
@@ -22,8 +22,8 @@ yform_rest_token_added = Token skapades
 yform_rest_token_header_summary
 
 yform_rest_token_header_description
-yform_rest_token_not_found = Kunde inte hitta några tokens
-yform_rest_token_caption = List av alla tokens
+yform_rest_token_not_found = Kunde inte hitta några token
+yform_rest_token_caption = List av alla token
 
 yform_rest_token_name_validate = Vänligen ange en beteckning/ett namn
 yform_rest_token_token_validate = Vänligen skapa en token


### PR DESCRIPTION
Falls erwünscht. Ich hatte erst nach Fertigstellung des PRs gesehen, dass die Schreibweise `Tokens` auch gültig ist. Ich kenne den Plural von "Token" nur als "Token", nicht "Tokens".