### PR TITLE
Rekursives Sortieren aller JSON-Tableset-Export-Schlüssel

### DIFF
--- a/plugins/manager/lib/yform/manager/table/api.php
+++ b/plugins/manager/lib/yform/manager/table/api.php
@@ -117,6 +117,13 @@ class rex_yform_manager_table_api
      */
     public static function exportTablesets(array $table_names)
     {
+        $recursiveKsort = function(&$array) use (&$recursiveKsort) {
+            foreach ($array as &$value) {
+                if (is_array($value)) $recursiveKsort($value);
+            }
+            ksort($array);
+        };
+
         $export = [];
         foreach ($table_names as $table_name) {
             $export_table = rex_yform_manager_table::get($table_name);
@@ -130,17 +137,8 @@ class rex_yform_manager_table_api
             ];
         }
 
-        return json_encode(self::recursive_ksort($export), JSON_PRETTY_PRINT);
-    }
-    /**
-     * @param array $array
-     * @return array
-     */
-    public static function recursive_ksort(&$array) {
-        foreach ($array as &$value) {
-            if (is_array($value)) recursive_ksort($value);
-        }
-        return ksort($array);
+        $recursiveKsort($export);
+        return json_encode($export, JSON_PRETTY_PRINT);
     }
 
     /**

--- a/plugins/manager/lib/yform/manager/table/api.php
+++ b/plugins/manager/lib/yform/manager/table/api.php
@@ -130,7 +130,17 @@ class rex_yform_manager_table_api
             ];
         }
 
-        return json_encode($export, JSON_PRETTY_PRINT);
+        return json_encode(self::recursive_ksort($export), JSON_PRETTY_PRINT);
+    }
+    /**
+     * @param array $array
+     * @return array
+     */
+    public static function recursive_ksort(&$array) {
+        foreach ($array as &$value) {
+            if (is_array($value)) recursive_ksort($value);
+        }
+        return ksort($array);
     }
 
     /**

--- a/plugins/manager/lib/yform/manager/table/api.php
+++ b/plugins/manager/lib/yform/manager/table/api.php
@@ -131,13 +131,12 @@ class rex_yform_manager_table_api
             foreach ($export_table->getFields() as $field) {
                 $export_fields[] = array_diff_key($field->toArray(), ['id' => 0]);
             }
-            $export[$export_table['table_name']] = [
+            $export[$export_table['table_name']] = $recursiveKsort([
                 'table' => array_diff_key($export_table->toArray(), ['id' => 0, 'prio' => 0]),
                 'fields' => $export_fields,
-            ];
+            ](;
         }
 
-        $recursiveKsort($export);
         return json_encode($export, JSON_PRETTY_PRINT);
     }
 

--- a/plugins/manager/lib/yform/manager/table/api.php
+++ b/plugins/manager/lib/yform/manager/table/api.php
@@ -134,7 +134,7 @@ class rex_yform_manager_table_api
             $export[$export_table['table_name']] = $recursiveKsort([
                 'table' => array_diff_key($export_table->toArray(), ['id' => 0, 'prio' => 0]),
                 'fields' => $export_fields,
-            ](;
+            ]);
         }
 
         return json_encode($export, JSON_PRETTY_PRINT);


### PR DESCRIPTION
Einfachere Nachverfolgung von Änderungen, wenn das Tableset in einem GitHub-Repository aktualisiert wird (z.B. YForm-basierte Addons)