### PR TITLE
Widgets um Add und View Button ergänzt

### DIFF
--- a/plugins/manager/assets/widget.js
+++ b/plugins/manager/assets/widget.js
@@ -6,6 +6,8 @@ $(document).on('rex:ready',function() {
         let link = this.dataset.link;
         let widget_type = this.dataset.widget_type;
         let field_name = this.dataset.field_name;
+        let _csrf_token = this.dataset.csrf_token;
+        let value = this.dataset.value;
 
         $(this).find("a").each(function () {
 
@@ -18,6 +20,34 @@ $(document).on('rex:ready',function() {
             if (this.classList.contains('yform-dataset-widget-pool')) {
                 this.onclick = function () {
                     return newPoolWindow( link);
+                };
+            }
+
+            // add
+            if (this.classList.contains('yform-dataset-widget-add')) {
+                this.onclick = function () {
+                    let newWindowLink = link + '&_csrf_token='+ _csrf_token +'&func=add&rex_yform_manager_opener[id]='+id+'&rex_yform_manager_opener[field]='+field_name+'&rex_yform_manager_opener[multiple]='+multiple;
+                    return newWindow( id, newWindowLink, 1200,800,',status=yes,resizable=yes');
+                };
+            }
+
+            // view
+            if (value !== '' && this.classList.contains('yform-dataset-widget-view')) {
+                this.onclick = function () {
+                    let dataId = value;
+                    if (multiple === 1) {
+                        let viewObject = document.querySelector('#yform-dataset-view-'+id);
+                        for (let position = 0; position < viewObject.options.length; position++) {
+                            if (viewObject.options[position].selected) {
+                                dataId = viewObject.options[position].value;
+                                break;
+                            }
+                        }
+
+                    }
+
+                    let newWindowLink = link + '&_csrf_token='+ _csrf_token +'&func=edit&data_id=' + dataId + '&rex_yform_manager_opener[id]='+id+'&rex_yform_manager_opener[field]='+field_name+'&rex_yform_manager_opener[multiple]='+multiple;
+                    return newWindow( id, newWindowLink, 1200,800,',status=yes,resizable=yes');
                 };
             }
 

--- a/plugins/manager/lang/de_de.lang
+++ b/plugins/manager/lang/de_de.lang
@@ -20,8 +20,11 @@ yform_relation_move_first_data = Ausgewählten Datensatz an den Anfang verschieb
 yform_relation_move_up_data = Ausgewählten Datensatz nach oben verschieben
 yform_relation_move_down_data = Ausgewählten Datensatz nach unten verschieben
 yform_relation_move_last_data = Ausgewählten Datensatz an das Ende verschieben
+yform_relation_add_entry = Datensatz hinzufügen
 yform_relation_choose_entry = Datensatz auswählen
 yform_relation_delete_entry = Ausgewählten Datensatz löschen
+yform_relation_no_entry = Kein Datensatz zugewiesen
+yform_relation_view_entry = Datensatz ansehen
 yform_relation_first_create_data = Bitte zunächst diesen Datensatz erstellen
 yform_relation_edit_relations = Verknüpfungen verwalten
 

--- a/plugins/manager/lang/en_gb.lang
+++ b/plugins/manager/lang/en_gb.lang
@@ -18,8 +18,11 @@ yform_relation_move_first_data = Move selected entry to the top
 yform_relation_move_up_data = Move selected entry up
 yform_relation_move_down_data = Move selected entry down
 yform_relation_move_last_data = Move selected entry to the bottom
+yform_relation_add_entry = Add record
 yform_relation_choose_entry = Select record
 yform_relation_delete_entry = Delete selected record
+yform_relation_no_entry = No record selected
+yform_relation_view_entry = View record
 yform_relation_first_create_data = Please first create this record
 yform_relation_edit_relations = Edit relations
 

--- a/plugins/manager/lib/var_yform_dataset.php
+++ b/plugins/manager/lib/var_yform_dataset.php
@@ -133,7 +133,7 @@ class rex_var_yform_table_data extends rex_var
                 <a class="btn btn-popup yform-dataset-widget-open" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-view-list"></i></a>
                 <a class="btn btn-popup yform-dataset-widget-add" title="' . rex_i18n::msg('yform_relation_add_entry') . '"><i class="rex-icon rex-icon-add"></i></a>
                 <a class="btn btn-popup yform-dataset-widget-delete" title="' . rex_i18n::msg('yform_relation_delete_entry') . '"><i class="rex-icon rex-icon-remove"></i></a>
-            '.$viewButton;
+            ' . $viewButton;
         $e['before'] = '<div class="yform-dataset-widget"
             data-widget_type="multiple"
             data-id="' . $id . '"
@@ -169,7 +169,7 @@ class rex_var_yform_table_data extends rex_var
                 <a class="btn btn-popup yform-dataset-widget-open" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-view-list"></i></a>
                 <a class="btn btn-popup yform-dataset-widget-add" title="' . rex_i18n::msg('yform_relation_add_entry') . '"><i class="rex-icon rex-icon-add"></i></a>
                 <a class="btn btn-popup yform-dataset-widget-delete" title="' . rex_i18n::msg('yform_relation_delete_entry') . '"><i class="rex-icon rex-icon-remove"></i></a>
-                '.$viewButton;
+                ' . $viewButton;
         $e['before'] = '<div class="yform-dataset-widget"
             data-widget_type="single"
             data-id="' . $id . '"

--- a/plugins/manager/lib/var_yform_dataset.php
+++ b/plugins/manager/lib/var_yform_dataset.php
@@ -115,6 +115,11 @@ class rex_var_yform_table_data extends rex_var
             $select->addOption($option['name'], $option['id']);
         }
 
+        $viewButton = '<a class="btn btn-popup yform-dataset-widget-view" title="' . rex_i18n::msg('yform_relation_view_entry') . '"><i class="rex-icon rex-icon-view"></i></a>';
+        if ('' === $value) {
+            $viewButton = '<span class="btn btn-popup" title="' . rex_i18n::msg('yform_relation_no_entry') . '"><i class="rex-icon rex-icon-hide"></i></span>';
+        }
+
         $e = [];
         $e['field'] = $select->get() . '
                 <input type="hidden" class="yform-dataset-real" name="' . $name . '" id="' . $dataset_real_id . '" value="' . rex_escape($value) . '" />';
@@ -125,13 +130,15 @@ class rex_var_yform_table_data extends rex_var
                 <a class="btn btn-popup yform-dataset-widget-move yform-dataset-widget-move-down" title="' . rex_i18n::msg('yform_relation_down_first_data') . '"><i class="rex-icon rex-icon-down"></i></a>
                 <a class="btn btn-popup yform-dataset-widget-move yform-dataset-widget-move-bottom" title="' . rex_i18n::msg('yform_relation_move_last_data') . '"><i class="rex-icon rex-icon-bottom"></i></a>';
         $e['functionButtons'] = '
-                <a class="btn btn-popup yform-dataset-widget-open" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-add"></i></a>
+                <a class="btn btn-popup yform-dataset-widget-open" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-view-list"></i></a>
+                <a class="btn btn-popup yform-dataset-widget-add" title="' . rex_i18n::msg('yform_relation_add_entry') . '"><i class="rex-icon rex-icon-add"></i></a>
                 <a class="btn btn-popup yform-dataset-widget-delete" title="' . rex_i18n::msg('yform_relation_delete_entry') . '"><i class="rex-icon rex-icon-remove"></i></a>
-            ';
+            '.$viewButton;
         $e['before'] = '<div class="yform-dataset-widget"
             data-widget_type="multiple"
             data-id="' . $id . '"
             data-link="' . $link . '"
+            data-csrf_token="' . urlencode($args['_csrf_token']) . '"
             data-field_name="' . urlencode($args['fieldName']) . '">';
         $e['after'] = '</div>';
 
@@ -150,18 +157,26 @@ class rex_var_yform_table_data extends rex_var
         $dataset_view_id = 'yform-dataset-view-' . $id . '';
         $dataset_real_id = 'yform-dataset-real-' . $id . '';
 
+        $viewButton = '<a class="btn btn-popup yform-dataset-widget-view" title="' . rex_i18n::msg('yform_relation_view_entry') . '"><i class="rex-icon rex-icon-view"></i></a>';
+        if ('' === $value) {
+            $viewButton = '<span class="btn btn-popup" title="' . rex_i18n::msg('yform_relation_no_entry') . '"><i class="rex-icon rex-icon-hide"></i></span>';
+        }
+
         $e['field'] = '
             <input class="form-control yform-dataset-view" type="text" value="' . $valueName . '" id="' . $dataset_view_id . '" readonly="readonly" />
             <input type="hidden" class="yform-dataset-real" name="' . $name . '" id="' . $dataset_real_id . '" value="' . $value . '" />';
         $e['functionButtons'] = '
-                <a class="btn btn-popup yform-dataset-widget-open" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-add"></i></a>
-                <a class="btn btn-popup yform-dataset-widget-delete" title="' . rex_i18n::msg('yform_relation_delete_entry') . '"><i class="rex-icon rex-icon-remove"></i></a>';
+                <a class="btn btn-popup yform-dataset-widget-open" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-view-list"></i></a>
+                <a class="btn btn-popup yform-dataset-widget-add" title="' . rex_i18n::msg('yform_relation_add_entry') . '"><i class="rex-icon rex-icon-add"></i></a>
+                <a class="btn btn-popup yform-dataset-widget-delete" title="' . rex_i18n::msg('yform_relation_delete_entry') . '"><i class="rex-icon rex-icon-remove"></i></a>
+                '.$viewButton;
         $e['before'] = '<div class="yform-dataset-widget"
             data-widget_type="single"
             data-id="' . $id . '"
             data-value_name="' . $valueName . '"
             data-value="' . $value . '"
             data-link="' . $link . '"
+            data-csrf_token="' . urlencode($args['_csrf_token']) . '"
             data-field_name="' . urlencode($args['fieldName']) . '">';
         $e['after'] = '</div>';
 

--- a/plugins/manager/ytemplates/bootstrap/value.be_manager_relation.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_manager_relation.tpl.php
@@ -71,6 +71,8 @@ $e = [];
         $args['link'] = $link;
         $args['fieldName'] = $this->getRelationSourceTableName() . '.' . $this->getName();
         $args['valueName'] = $valueName;
+        $_csrf_key = rex_yform_manager_table::get($this->relation['target_table'])->getCSRFKey();
+        $args += rex_csrf_token::factory($_csrf_key)->getUrlParams();
         $value = implode(',', $this->getValue());
         echo \rex_var_yform_table_data::getSingleWidget($id, $name, $value, $args);
     } else {
@@ -81,6 +83,8 @@ $e = [];
         $args['fieldName'] = $this->getRelationSourceTableName() . '.' . $this->getName();
         $args['size'] = $this->getRelationSize();
         $args['attributes'] = $this->getAttributeArray([], ['required', 'readonly']);
+        $_csrf_key = rex_yform_manager_table::get($this->relation['target_table'])->getCSRFKey();
+        $args += rex_csrf_token::factory($_csrf_key)->getUrlParams();
         $value = implode(',', $this->getValue());
         echo \rex_var_yform_table_data::getMultipleWidget($id, $name, $value, $args);
     }


### PR DESCRIPTION
YForm Widgets an den Core Widgets angepasst.

- `list` öffnet die Liste.
- `+` öffnet jetzt nicht mehr die Liste sondern man kann direkt einen Datensatz anlegen.
- `auge` öffnet den Datensatz in der Edit-Ansicht.

**Vorher**

<img width="761" alt="Bildschirmfoto 2024-02-29 um 15 50 30" src="https://github.com/yakamara/yform/assets/338267/3256d8f5-b1b8-4891-856c-dfb383573438">

**Nachher**

<img width="762" alt="Bildschirmfoto 2024-02-29 um 15 49 56" src="https://github.com/yakamara/yform/assets/338267/2d05bb72-89b9-4de8-8f46-6843aa530061">
