### PR TITLE
i18n-Translate für die Table-Description

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -127,7 +127,7 @@ class rex_yform_manager
             $this->setLinkVars($searchObject->getSearchVars());
         }
 
-        $description = $popup || ('' == $this->table->getDescription()) ? '' : '<p>' . nl2br(rex_escape($this->table->getDescription())) . '</p>';
+        $description = $popup || ('' == $this->table->getDescription()) ? '' : '<p>' . nl2br(rex_escape(rex_i18n::translate($this->table->getDescription()))) . '</p>';
 
         echo rex_extension::registerPoint(
             new rex_extension_point(


### PR DESCRIPTION
Ist das mal irgendwann kürzlich hintenüber gefallen?

Die TableDescription wird jedenfalls nicht (mehr) durch `rex_18n::translate` geschickt, was dann zu solchen Ausgaben führt:

<img width="572" alt="grafik" src="https://github.com/yakamara/yform/assets/10065904/ac82cb8d-efd9-4e96-8b95-c7f595e8c504">

Aus irgend einem Grund bin ich der Meinung, dass das mal anders war. Der PR behebt das Problem.