### PR TITLE
Revert the final keywords for dataset methods

### DIFF
--- a/plugins/manager/lib/yform/manager/dataset.php
+++ b/plugins/manager/lib/yform/manager/dataset.php
@@ -743,7 +743,7 @@ class rex_yform_manager_dataset
     /**
      * @internal
      */
-    final protected static function modelToTable(): string
+    protected static function modelToTable(): string
     {
         $class = static::class;
 


### PR DESCRIPTION
Remove the final keyword, as the signature change breaks existing code.

This fixes #1498