### PR TITLE
manager: Add Custom Icon for Tables 

### DIFF
--- a/plugins/manager/boot.php
+++ b/plugins/manager/boot.php
@@ -49,8 +49,8 @@ if (rex::isBackend() && rex::getUser()) {
         if ($table->isActive() && $table->isGranted('VIEW', rex::getUser())) {
             $be_page = new rex_be_page_main('yform_tables', $table->getTableName(), rex_escape($table->getNameLocalized()));
             $be_page->setHref('index.php?page=yform/manager/data_edit&table_name=' . $table->getTableName());
-            $icon = rex_escape($table->getCustomIcon() ?: 'rex-icon rex-icon-module');
-            $be_page->setIcon($icon);
+            $icon = rex_escape($table->getCustomIcon() ?: 'rex-icon-module');
+            $be_page->setIcon('rex-icon ' . $icon);
             $be_page->setPrio($prio);
 
             if ($table->isHidden()) {

--- a/plugins/manager/boot.php
+++ b/plugins/manager/boot.php
@@ -49,7 +49,8 @@ if (rex::isBackend() && rex::getUser()) {
         if ($table->isActive() && $table->isGranted('VIEW', rex::getUser())) {
             $be_page = new rex_be_page_main('yform_tables', $table->getTableName(), rex_escape($table->getNameLocalized()));
             $be_page->setHref('index.php?page=yform/manager/data_edit&table_name=' . $table->getTableName());
-            $be_page->setIcon('rex-icon rex-icon-module');
+            $icon = rex_escape($table->getCustomIcon() ?: 'rex-icon rex-icon-module');
+            $be_page->setIcon($icon);
             $be_page->setPrio($prio);
 
             if ($table->isHidden()) {

--- a/plugins/manager/install.php
+++ b/plugins/manager/install.php
@@ -23,6 +23,7 @@ $table
     ->ensureColumn(new rex_sql_column('table_name', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('name', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('description', 'text'))
+    ->ensureColumn(new rex_sql_column('table_icon', 'text'))
     ->ensureColumn(new rex_sql_column('list_amount', 'int(11)', false, '50'))
     ->ensureColumn(new rex_sql_column('list_sortfield', 'varchar(191)', false, 'id'))
     ->ensureColumn(new rex_sql_column('list_sortorder', 'enum(\'ASC\',\'DESC\')', false, 'ASC'))

--- a/plugins/manager/install.php
+++ b/plugins/manager/install.php
@@ -23,7 +23,7 @@ $table
     ->ensureColumn(new rex_sql_column('table_name', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('name', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('description', 'text'))
-    ->ensureColumn(new rex_sql_column('table_icon', 'text(191)'))
+    ->ensureColumn(new rex_sql_column('table_icon', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('list_amount', 'int(11)', false, '50'))
     ->ensureColumn(new rex_sql_column('list_sortfield', 'varchar(191)', false, 'id'))
     ->ensureColumn(new rex_sql_column('list_sortorder', 'enum(\'ASC\',\'DESC\')', false, 'ASC'))

--- a/plugins/manager/install.php
+++ b/plugins/manager/install.php
@@ -23,7 +23,7 @@ $table
     ->ensureColumn(new rex_sql_column('table_name', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('name', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('description', 'text'))
-    ->ensureColumn(new rex_sql_column('table_icon', 'text'))
+    ->ensureColumn(new rex_sql_column('table_icon', 'text(191)'))
     ->ensureColumn(new rex_sql_column('list_amount', 'int(11)', false, '50'))
     ->ensureColumn(new rex_sql_column('list_sortfield', 'varchar(191)', false, 'id'))
     ->ensureColumn(new rex_sql_column('list_sortorder', 'enum(\'ASC\',\'DESC\')', false, 'ASC'))

--- a/plugins/manager/lang/de_de.lang
+++ b/plugins/manager/lang/de_de.lang
@@ -67,6 +67,7 @@ yform_manager_table_name = Name
 yform_manager_table_status = Status
 yform_manager_name = Bezeichnung
 yform_manager_table_description = Beschreibung
+yform_manager_custom_icon = Individuelles Icon
 yform_manager_entries_per_page = Datensätze pro Seite
 yform_manager_sortfield = Standardsortierung: Feld
 yform_manager_sortorder = Richtung

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -241,7 +241,7 @@ final class rex_yform_manager_table implements ArrayAccess
         return $this->values['description'];
     }
 
-    public function getCustomIcon(): string
+    public function getCustomIcon(): ?string
     {
         return $this->values['table_icon'];
     }

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -240,6 +240,11 @@ final class rex_yform_manager_table implements ArrayAccess
     {
         return $this->values['description'];
     }
+    
+    public function getCustomIcon(): string
+    {
+        return $this->values['table_icon'];
+    }
 
     /**
      * Fields of yform Definitions.

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -240,7 +240,7 @@ final class rex_yform_manager_table implements ArrayAccess
     {
         return $this->values['description'];
     }
-    
+
     public function getCustomIcon(): string
     {
         return $this->values['table_icon'];

--- a/plugins/manager/lib/yform/manager/table/api.php
+++ b/plugins/manager/lib/yform/manager/table/api.php
@@ -3,7 +3,7 @@
 class rex_yform_manager_table_api
 {
     /** @var array<int, string> */
-    public static array $table_fields = ['status', 'name', 'description', 'list_amount', 'list_sortfield', 'list_sortorder', 'prio', 'search', 'hidden', 'export', 'import', 'schema_overwrite'];
+    public static array $table_fields = ['status', 'name', 'description', 'table_icon', 'list_amount', 'list_sortfield', 'list_sortorder', 'prio', 'search', 'hidden', 'export', 'import', 'schema_overwrite'];
     public static bool $debug = false;
     public static array $cacheColumnsByTable = [];
 

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -122,7 +122,7 @@ if ('tableset_import' == $func && rex::getUser()->isAdmin()) {
     $yform->setValidateField('empty', ['name', rex_i18n::msg('yform_manager_table_enter_name')]);
     $yform->setValueField('textarea', ['description', '<br />' . rex_i18n::msg('yform_manager_table_description'), 'attributes' => '{"class":"form-control yform-textarea-short"}']);
     $yform->setValueField('text', ['table_icon', rex_i18n::msg('yform_manager_custom_icon')]);
-    
+
     $yform->setValueField('html', ['html' => '</div><div class="col-md-6">']);
 
     $yform->setValueField('html', ['html' => '<label>' . rex_i18n::msg('yform_manager_table_func') . '</label>']);

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -121,7 +121,7 @@ if ('tableset_import' == $func && rex::getUser()->isAdmin()) {
     $yform->setValueField('text', ['name', rex_i18n::msg('yform_manager_name')]);
     $yform->setValidateField('empty', ['name', rex_i18n::msg('yform_manager_table_enter_name')]);
     $yform->setValueField('textarea', ['description', '<br />' . rex_i18n::msg('yform_manager_table_description'), 'attributes' => '{"class":"form-control yform-textarea-short"}']);
-    $yform->setValueField('text', ['table_icon', rex_i18n::msg('yform_manager_custom_icon')]);
+    $yform->setValueField('text', ['table_icon', rex_i18n::msg('yform_manager_custom_icon'), 'attributes' => '{"class":"form-control yform-table-icon"}']);
 
     $yform->setValueField('html', ['html' => '</div><div class="col-md-6">']);
 

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -121,7 +121,8 @@ if ('tableset_import' == $func && rex::getUser()->isAdmin()) {
     $yform->setValueField('text', ['name', rex_i18n::msg('yform_manager_name')]);
     $yform->setValidateField('empty', ['name', rex_i18n::msg('yform_manager_table_enter_name')]);
     $yform->setValueField('textarea', ['description', '<br />' . rex_i18n::msg('yform_manager_table_description'), 'attributes' => '{"class":"form-control yform-textarea-short"}']);
-
+    $yform->setValueField('text', ['table_icon', rex_i18n::msg('yform_manager_custom_icon')]);
+    
     $yform->setValueField('html', ['html' => '</div><div class="col-md-6">']);
 
     $yform->setValueField('html', ['html' => '<label>' . rex_i18n::msg('yform_manager_table_func') . '</label>']);


### PR DESCRIPTION
<img width="1371" alt="Bildschirmfoto 2024-08-22 um 12 34 00" src="https://github.com/user-attachments/assets/0358c17f-4abc-4e37-a87f-4aea1d7ee310">


<img width="238" alt="Bildschirmfoto 2024-08-22 um 12 34 47" src="https://github.com/user-attachments/assets/9cd25cdc-33b8-4114-90ec-cce62315a91e">

Getestet mit Font-Awesome Icons

- rex-icon präfix wird automatisch gesetzt
- Wenn leer, wird das default icon genommen
- Natürlich mit rex_escape behandelt

Beispiel: 
<img width="234" alt="Bildschirmfoto 2024-08-23 um 09 40 29" src="https://github.com/user-attachments/assets/3b17ca45-1638-4886-9dff-c00c84f7159c">


