### PR TITLE
Table Manager: Feldverwaltung - 100 statt 30 Einträge zeigen

### DIFF
--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -231,7 +231,7 @@ final class rex_yform_manager_table implements ArrayAccess
     public function getListAmount()
     {
         if (!isset($this->values['list_amount']) || $this->values['list_amount'] < 1) {
-            $this->values['list_amount'] = 30;
+            $this->values['list_amount'] = 100;
         }
         return $this->values['list_amount'];
     }


### PR DESCRIPTION
Damit Drag & Drop von `yform_usability` auch für mehr als 30 Einträge funktioniert.

Es gibt gute Gründe, 100 Felder verwalten zu können und wer das macht, nimmt auch einen längeren Aufbau der Seite inkauf

Da es ohnehin keine Suchfunktion für Felder gibt, ist auch ohne `yform_usability` die browsereigene Suchfunktion somit nutzbar, ohne sich von Seite zu Seite zu kämpfen.