### PR TITLE
fix submit value to use its parameter values as values, not its labels

### DIFF
--- a/lib/yform/value/submit.php
+++ b/lib/yform/value/submit.php
@@ -59,7 +59,7 @@ class rex_yform_value_submit extends rex_yform_value_abstract
         if ($this->needsOutput() && $this->isViewable()) {
             if (!$this->isEditable()) {
             } else {
-                $this->params['form_output'][$this->getId()] = $this->parse('value.submit.tpl.php', compact('labels'));
+                $this->params['form_output'][$this->getId()] = $this->parse('value.submit.tpl.php', compact('labels', 'values'));
             }
         }
 

--- a/ytemplates/bootstrap/value.submit.tpl.php
+++ b/ytemplates/bootstrap/value.submit.tpl.php
@@ -6,6 +6,7 @@
  */
 
 $labels ??= [];
+$values ??= [];
 
 $css_classes = [];
 if ('' != $this->getElement('css_classes')) {
@@ -35,7 +36,7 @@ foreach ($labels as $index => $label) {
     $id = $this->getFieldId() . '-' . rex_string::normalize($label);
     $label_translated = rex_i18n::translate($label, true);
 
-    echo '<button class="' . implode(' ', $classes) . '" type="submit" name="' . $this->getFieldName() . '" id="' . $id . '" value="' . rex_escape($label) . '">' . $label_translated . '</button>';
+    echo '<button class="' . implode(' ', $classes) . '" type="submit" name="' . $this->getFieldName() . '" id="' . $id . '" value="' . rex_escape($values[$index]) . '">' . $label_translated . '</button>';
 }
 
 if (count($labels) > 1) {


### PR DESCRIPTION
Beim yform submit field kann man labels und values für mehrere submit buttons angeben.

```
public function getDescription(): string
    {
        return 'submit|name|labelvalue1_on_button1,labelvalue2_on_button2| [value_1_to_save_if_clicked,value_2_to_save_if_clicked] | [no_db] | [Default-Wert] | [cssclassname1,cssclassname2]';
    }
```
Es wurden bisher aber nur die labels benutzt.