### PR TITLE
Mehrseitige Listen - beim erneuten Seitenaufbau kommt man immer auf Seite 1

### DIFF
--- a/lib/manager/manager.php
+++ b/lib/manager/manager.php
@@ -84,7 +84,7 @@ class rex_yform_manager
         $rex_yform_list['list'] = rex_request('list', 'string');
         $rex_yform_list['sort'] = rex_request('sort', 'string');
         $rex_yform_list['sorttype'] = rex_request('sorttype', 'string');
-        $rex_yform_list['start'] = rex_request('start', 'int', null) ?? rex_request($rex_yform_list['list'] . '_start', 'int', null) ?? 0;
+        $rex_yform_list['start'] = rex_request($rex_yform_list['list'] . '_start', 'int', null) ?? rex_request('start', 'int', null) ?? 0;
 
         $_csrf_key = $this->table->getCSRFKey();
         $rex_yform_list += rex_csrf_token::factory($_csrf_key)->getUrlParams();


### PR DESCRIPTION
fix for #1425

Nach der sauberen Vorarbeit von @christophboecker schlage ich mal diesen Fix vor.
Weil ich gerade selbst dutzende Datensätze manuell im BE bearbeite und da nervt das!

change order of read "start"-params

Mir erscheint es logisch erst den "xxxx_start" Parameter auszuwerten und dann, wenn der nicht existiert den "start" zu nehmen.
Aber ob das überall passt, oder irgendwo anders Probleme erzeugt, weiß @dergel  am besten.